### PR TITLE
Update gpio-nct5104d.c

### DIFF
--- a/gpio-nct5104d.c
+++ b/gpio-nct5104d.c
@@ -289,13 +289,8 @@ static int nct5104d_gpio_probe(struct platform_device *pdev)
 err_gpiochip:
 	for (i = i - 1; i >= 0; i--) {
 		struct nct5104d_gpio_bank *bank = &data->bank[i];
-		int tmp;
 
-		tmp = gpiochip_remove(&bank->chip);
-		if (tmp < 0)
-			dev_err(&pdev->dev,
-				"Failed to remove gpiochip %d: %d\n",
-				i, tmp);
+		gpiochip_remove(&bank->chip);
 	}
 
 	return err;
@@ -303,20 +298,12 @@ err_gpiochip:
 
 static int nct5104d_gpio_remove(struct platform_device *pdev)
 {
-	int err;
 	int i;
 	struct nct5104d_gpio_data *data = platform_get_drvdata(pdev);
 
 	for (i = 0; i < data->nr_bank; i++) {
 		struct nct5104d_gpio_bank *bank = &data->bank[i];
-
-		err = gpiochip_remove(&bank->chip);
-		if (err) {
-			dev_err(&pdev->dev,
-				"Failed to remove GPIO gpiochip %d: %d\n",
-				i, err);
-			return err;
-		}
+		gpiochip_remove(&bank->chip);
 	}
 
 	return 0;


### PR DESCRIPTION
In newer kernels gpiochip_remove function is void, therefore this patch will fix compilation errors.
Tested on APU2 with linux kernel 4.4.9 & 4.4.13
