### PR TITLE
Fix for struct gpio_chip change in kernel 4.5.0

### DIFF
--- a/gpio-nct5104d.c
+++ b/gpio-nct5104d.c
@@ -289,13 +289,8 @@ static int nct5104d_gpio_probe(struct platform_device *pdev)
 err_gpiochip:
 	for (i = i - 1; i >= 0; i--) {
 		struct nct5104d_gpio_bank *bank = &data->bank[i];
-		int tmp;
 
-		tmp = gpiochip_remove(&bank->chip);
-		if (tmp < 0)
-			dev_err(&pdev->dev,
-				"Failed to remove gpiochip %d: %d\n",
-				i, tmp);
+		gpiochip_remove(&bank->chip);
 	}
 
 	return err;
@@ -303,20 +298,12 @@ err_gpiochip:
 
 static int nct5104d_gpio_remove(struct platform_device *pdev)
 {
-	int err;
 	int i;
 	struct nct5104d_gpio_data *data = platform_get_drvdata(pdev);
 
 	for (i = 0; i < data->nr_bank; i++) {
 		struct nct5104d_gpio_bank *bank = &data->bank[i];
-
-		err = gpiochip_remove(&bank->chip);
-		if (err) {
-			dev_err(&pdev->dev,
-				"Failed to remove GPIO gpiochip %d: %d\n",
-				i, err);
-			return err;
-		}
+		gpiochip_remove(&bank->chip);
 	}
 
 	return 0;

--- a/gpio-nct5104d.c
+++ b/gpio-nct5104d.c
@@ -14,6 +14,7 @@
 #include <linux/platform_device.h>
 #include <linux/io.h>
 #include <linux/gpio.h>
+#include <linux/version.h>
 
 #define DRVNAME "gpio-nct5104d"
 
@@ -272,7 +273,11 @@ static int nct5104d_gpio_probe(struct platform_device *pdev)
 	for (i = 0; i < data->nr_bank; i++) {
 		struct nct5104d_gpio_bank *bank = &data->bank[i];
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
+		bank->chip.parent = &pdev->dev;
+#else
 		bank->chip.dev = &pdev->dev;
+#endif
 		bank->data = data;
 
 		err = gpiochip_add(&bank->chip);


### PR DESCRIPTION
struct gpio_chip had 'dev' renamed to 'parent' here:
https://github.com/torvalds/linux/commit/58383c78425e4ee1c077253cf297b641c861c02e

To compile the module you also need jb's other fix:
https://github.com/tasanakorn/linux-gpio-nct5104d/pull/6/commits/6ec19fad37fdd4b88a71a74d92d4e7627ee9c209